### PR TITLE
Update free-programming-books-langs.md

### DIFF
--- a/books/free-programming-books-langs.md
+++ b/books/free-programming-books-langs.md
@@ -680,6 +680,10 @@ Books on general-purpose programming that don't focus on a specific language are
 * [Expert Delphi](https://www.packtpub.com/free-ebooks/expert-delphi) - Paweł Głowacki (Packt account *required*)
 * [Modern Object Pascal Introduction for Programmers](https://github.com/michaliskambi/modern-pascal-introduction) - Michalis Kamburelis ([AsciiDoc](https://github.com/michaliskambi/modern-pascal-introduction/blob/master/modern_pascal_introduction.adoc#logical-relational-and-bit-wise-operators), [HTML](https://castle-engine.io/modern_pascal_introduction.html), [PDF](https://castle-engine.io/modern_pascal_introduction.pdf))
 
+### Docker
+
+* [Introduction to Docker](https://github.com/bobbyiliev/introduction-to-docker-ebook) - Bobby Iliev (Markdown, PDF, EPUB)
+* [The Docker Handbook](https://www.freecodecamp.org/news/the-docker-handbook/) - Farhan Hasin Chowdhury (HTML)
 
 ### DTrace
 
@@ -1432,6 +1436,9 @@ Books on general-purpose programming that don't focus on a specific language are
 * [TeX by Topic, A TeXnician's Reference](http://eijkhout.net/texbytopic/texbytopic.html) - Victor Eijkhout
 * [TeX for the Impatient](https://www.gnu.org/software/teximpatient/) - Paul Abrahams, Kathryn Hargreaves, Karl Berry
 
+### Kubernetes
+
+* [The Kubernetes Handbook](https://www.freecodecamp.org/news/the-kubernetes-handbook/) - Farhan Hasin Chowdhury (HTML)
 
 ### Language Agnostic
 
@@ -2505,6 +2512,10 @@ Books on general-purpose programming that don't focus on a specific language are
 
 * [Teradata Books](http://www.info.teradata.com)
 
+
+### Terraform
+
+* [Terraform Tutorials](https://developer.hashicorp.com/terraform/tutorials) - HashiCorp (HTML)
 
 ### Tizen
 


### PR DESCRIPTION
Added ebook links for terraform, docker and kubernetes

## What does this PR do?
Add resource(s)

## For resources
### Description
Added resources in english for Docker, Kubernetes, and Terraform
### Why is this valuable (or not)?
The repo previously didnt have books for docker, kubernetes and terraform 
### How do we know it's really free?
1 of them links to a github repo that explain docker chapterwise from a book
2 are from freecodecamp and terraform from hashicorp

### For book lists, is it a book? For course lists, is it a course? etc.
they are more of learning path which is taught chapterwise.

## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
